### PR TITLE
Add protocol to repository URL in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 	"files":        ["cli.js", "lib/*", "js/*", "css/*"],
 	"author":       "Jannis R <mail@jannisr.de>",
 	"homepage":     "https://github.com/derhuerst/casket",
-	"repository":   "github.com/derhuerst/casket",
+	"repository":   "https://github.com/derhuerst/casket",
 	"bugs":         "https://github.com/derhuerst/casket/issues",
 	"license":      "ISC",
 	"preferGlobal": true,

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 	"files":        ["cli.js", "lib/*", "js/*", "css/*"],
 	"author":       "Jannis R <mail@jannisr.de>",
 	"homepage":     "https://github.com/derhuerst/casket",
-	"repository":   "https://github.com/derhuerst/casket",
+	"repository":   "derhuerst/casket",
 	"bugs":         "https://github.com/derhuerst/casket/issues",
 	"license":      "ISC",
 	"preferGlobal": true,


### PR DESCRIPTION
Should now pass validator at https://zeke.github.io/github-url-to-object/ and URL will hopefully show up on https://www.npmjs.com/package/casket after next npm publish.
